### PR TITLE
Potential fix for code scanning alert no. 3: Expression injection in Actions

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Check Issue Body Format
         id: check-body
         if: steps.check-title.outputs.is-gov-issue == 'true'
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          ISSUE_BODY="${{ github.event.issue.body }}"
-
           # Handle empty issue body
           if [[ -z "$ISSUE_BODY" ]]; then
             echo "has-valid-body=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Potential fix for [https://github.com/ringecosystem/gov-helper/security/code-scanning/3](https://github.com/ringecosystem/gov-helper/security/code-scanning/3)

To fix the problem, we need to avoid using the `${{ github.event.issue.body }}` directly within the shell script. Instead, we should assign the value to an environment variable and then use the shell's native syntax to reference this variable. This approach will prevent any potential command injection vulnerabilities.

We will:
1. Define an environment variable for `ISSUE_BODY` using `${{ github.event.issue.body }}`.
2. Use the shell's native syntax to reference this environment variable within the script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
